### PR TITLE
move module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# WARNING
+
+**This repo is archived. Please check the forked one https://github.com/feederco/go-socket.io.**
+
 # go-socket.io
 
 go-socket.io is library an implementation of [Socket.IO](http://socket.io) in Golang, which is a realtime application framework.

--- a/_examples/client/main.go
+++ b/_examples/client/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	socketio "github.com/googollee/go-socket.io"
+	socketio "github.com/feederco/go-socket.io"
 )
 
 func main() {

--- a/client.go
+++ b/client.go
@@ -6,11 +6,11 @@ import (
 	"path"
 	"strings"
 
-	"github.com/googollee/go-socket.io/engineio"
-	"github.com/googollee/go-socket.io/engineio/transport"
-	"github.com/googollee/go-socket.io/engineio/transport/polling"
-	"github.com/googollee/go-socket.io/logger"
-	"github.com/googollee/go-socket.io/parser"
+	"github.com/feederco/go-socket.io/engineio"
+	"github.com/feederco/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/transport/polling"
+	"github.com/feederco/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/parser"
 )
 
 var EmptyAddrErr = errors.New("empty addr")

--- a/connection.go
+++ b/connection.go
@@ -8,8 +8,8 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/googollee/go-socket.io/engineio"
-	"github.com/googollee/go-socket.io/parser"
+	"github.com/feederco/go-socket.io/engineio"
+	"github.com/feederco/go-socket.io/parser"
 )
 
 // Conn is a connection in go-socket.io

--- a/connection_handlers.go
+++ b/connection_handlers.go
@@ -3,8 +3,8 @@ package socketio
 import (
 	"log"
 
-	"github.com/googollee/go-socket.io/logger"
-	"github.com/googollee/go-socket.io/parser"
+	"github.com/feederco/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/parser"
 )
 
 var emtpyFH = newAckFunc(func() {})

--- a/connection_handlers_test.go
+++ b/connection_handlers_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/session"
-	"github.com/googollee/go-socket.io/parser"
+	"github.com/feederco/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/parser"
 )
 
 type testStr struct {

--- a/engineio/_examples/main.go
+++ b/engineio/_examples/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http/httptest"
 
-	"github.com/googollee/go-socket.io/engineio"
+	"github.com/feederco/go-socket.io/engineio"
 )
 
 func main() {

--- a/engineio/client.go
+++ b/engineio/client.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/session"
-	"github.com/googollee/go-socket.io/engineio/transport"
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/logger"
 )
 
 // Opener is client connection which need receive open message first.

--- a/engineio/connect.go
+++ b/engineio/connect.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/googollee/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/engineio/session"
 )
 
 // Conn is connection by client session

--- a/engineio/dialer.go
+++ b/engineio/dialer.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/transport"
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/logger"
 )
 
 // Dialer is dialer configure.

--- a/engineio/packet/decoder.go
+++ b/engineio/packet/decoder.go
@@ -3,7 +3,7 @@ package packet
 import (
 	"io"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 // FrameReader is the reader which supports framing.

--- a/engineio/packet/decoder_test.go
+++ b/engineio/packet/decoder_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 var tests = []struct {

--- a/engineio/packet/encoder.go
+++ b/engineio/packet/encoder.go
@@ -3,8 +3,8 @@ package packet
 import (
 	"io"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/logger"
 )
 
 // FrameWriter is the writer which supports framing.

--- a/engineio/packet/encoder_test.go
+++ b/engineio/packet/encoder_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 func TestEncoder(t *testing.T) {

--- a/engineio/packet/fake_discarder.go
+++ b/engineio/packet/fake_discarder.go
@@ -3,7 +3,7 @@ package packet
 import (
 	"io"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 type fakeOneFrameDiscarder struct{}

--- a/engineio/packet/fake_frame.go
+++ b/engineio/packet/fake_frame.go
@@ -3,7 +3,7 @@ package packet
 import (
 	"bytes"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 type fakeFrame struct {

--- a/engineio/packet/fake_reader.go
+++ b/engineio/packet/fake_reader.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 type fakeConnReader struct {

--- a/engineio/packet/fake_writer.go
+++ b/engineio/packet/fake_writer.go
@@ -3,7 +3,7 @@ package packet
 import (
 	"io"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 type fakeConnWriter struct {

--- a/engineio/packet/packet.go
+++ b/engineio/packet/packet.go
@@ -1,6 +1,6 @@
 package packet
 
-import "github.com/googollee/go-socket.io/engineio/frame"
+import "github.com/feederco/go-socket.io/engineio/frame"
 
 // Type is the type of packet
 type Type int

--- a/engineio/packet/packet_test.go
+++ b/engineio/packet/packet_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 func TestPacketType(t *testing.T) {

--- a/engineio/packet/types.go
+++ b/engineio/packet/types.go
@@ -1,7 +1,7 @@
 package packet
 
 import (
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 type Frame struct {

--- a/engineio/payload/data_test.go
+++ b/engineio/payload/data_test.go
@@ -1,8 +1,8 @@
 package payload
 
 import (
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
 )
 
 type Packet struct {

--- a/engineio/payload/decoder.go
+++ b/engineio/payload/decoder.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
 )
 
 type byteReader interface {

--- a/engineio/payload/encoder.go
+++ b/engineio/payload/encoder.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"unicode/utf8"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
 )
 
 type writerFeeder interface {

--- a/engineio/payload/encoder_test.go
+++ b/engineio/payload/encoder_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
 )
 
 type fakeWriterFeeder struct {

--- a/engineio/payload/payload.go
+++ b/engineio/payload/payload.go
@@ -7,8 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
 )
 
 type readArg struct {

--- a/engineio/payload/payload_test.go
+++ b/engineio/payload/payload_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
 )
 
 func TestPayloadFeedIn(t *testing.T) {

--- a/engineio/server.go
+++ b/engineio/server.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/googollee/go-socket.io/engineio/session"
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 // Server is instance of server

--- a/engineio/server_options.go
+++ b/engineio/server_options.go
@@ -1,13 +1,13 @@
 package engineio
 
 import (
-	"github.com/googollee/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/engineio/session"
 	"net/http"
 	"time"
 
-	"github.com/googollee/go-socket.io/engineio/transport"
-	"github.com/googollee/go-socket.io/engineio/transport/polling"
-	"github.com/googollee/go-socket.io/engineio/transport/websocket"
+	"github.com/feederco/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/transport/polling"
+	"github.com/feederco/go-socket.io/engineio/transport/websocket"
 )
 
 // Options is options to create a server.

--- a/engineio/server_test.go
+++ b/engineio/server_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/session"
-	"github.com/googollee/go-socket.io/engineio/transport"
-	"github.com/googollee/go-socket.io/engineio/transport/polling"
-	"github.com/googollee/go-socket.io/engineio/transport/websocket"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/transport/polling"
+	"github.com/feederco/go-socket.io/engineio/transport/websocket"
 )
 
 func TestEnginePolling(t *testing.T) {

--- a/engineio/session/base.go
+++ b/engineio/session/base.go
@@ -1,7 +1,7 @@
 package session
 
 import (
-	"github.com/googollee/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/frame"
 )
 
 // FrameType is type of message frame.

--- a/engineio/session/session.go
+++ b/engineio/session/session.go
@@ -8,11 +8,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/payload"
-	"github.com/googollee/go-socket.io/engineio/transport"
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/payload"
+	"github.com/feederco/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/logger"
 )
 
 // Pauser is connection which can be paused and resumes.

--- a/engineio/transport/polling/connect.go
+++ b/engineio/transport/polling/connect.go
@@ -11,11 +11,11 @@ import (
 	"net/url"
 	"sync/atomic"
 
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/payload"
-	"github.com/googollee/go-socket.io/engineio/transport"
-	"github.com/googollee/go-socket.io/engineio/transport/utils"
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/payload"
+	"github.com/feederco/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/transport/utils"
+	"github.com/feederco/go-socket.io/logger"
 )
 
 type clientConn struct {

--- a/engineio/transport/polling/connect_test.go
+++ b/engineio/transport/polling/connect_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 func TestDialOpen(t *testing.T) {

--- a/engineio/transport/polling/polling_test.go
+++ b/engineio/transport/polling/polling_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 var tests = []struct {

--- a/engineio/transport/polling/server.go
+++ b/engineio/transport/polling/server.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/googollee/go-socket.io/engineio/payload"
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/engineio/payload"
+	"github.com/feederco/go-socket.io/logger"
 )
 
 type serverConn struct {

--- a/engineio/transport/polling/server_test.go
+++ b/engineio/transport/polling/server_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 func TestServerJSONP(t *testing.T) {

--- a/engineio/transport/polling/transport.go
+++ b/engineio/transport/polling/transport.go
@@ -5,8 +5,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/googollee/go-socket.io/engineio/payload"
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/payload"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 // Transport is the transport of polling.

--- a/engineio/transport/transport.go
+++ b/engineio/transport/transport.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
 )
 
 // FrameReader reads a frame. It needs be closed before next reading.

--- a/engineio/transport/websocket/connect.go
+++ b/engineio/transport/websocket/connect.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 // conn implements base.Conn

--- a/engineio/transport/websocket/connect_test.go
+++ b/engineio/transport/websocket/connect_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 func TestWebsocketSetReadDeadline(t *testing.T) {

--- a/engineio/transport/websocket/transport.go
+++ b/engineio/transport/websocket/transport.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/gorilla/websocket"
 
-	"github.com/googollee/go-socket.io/engineio/transport"
-	"github.com/googollee/go-socket.io/engineio/transport/utils"
+	"github.com/feederco/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/transport/utils"
 )
 
 // DialError is the error when dialing to a server. It saves Response from

--- a/engineio/transport/websocket/websocket_test.go
+++ b/engineio/transport/websocket/websocket_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/packet"
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/packet"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 var tests = []struct {

--- a/engineio/transport/websocket/wrapper.go
+++ b/engineio/transport/websocket/wrapper.go
@@ -7,11 +7,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/logger"
 	"github.com/gorilla/websocket"
 
-	"github.com/googollee/go-socket.io/engineio/frame"
-	"github.com/googollee/go-socket.io/engineio/transport"
+	"github.com/feederco/go-socket.io/engineio/frame"
+	"github.com/feederco/go-socket.io/engineio/transport"
 )
 
 type wrapper struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/googollee/go-socket.io
+module github.com/feederco/go-socket.io
 
 go 1.16
 

--- a/namespace_conn.go
+++ b/namespace_conn.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/googollee/go-socket.io/parser"
+	"github.com/feederco/go-socket.io/parser"
 )
 
 // Namespace describes a communication channel that allows you to split the logic of your application

--- a/namespace_handler.go
+++ b/namespace_handler.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/googollee/go-socket.io/parser"
+	"github.com/feederco/go-socket.io/parser"
 )
 
 type namespaceHandler struct {

--- a/namespace_handler_test.go
+++ b/namespace_handler_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/googollee/go-socket.io/parser"
+	"github.com/feederco/go-socket.io/parser"
 )
 
 func TestNamespaceHandler(t *testing.T) {

--- a/parser/decoder.go
+++ b/parser/decoder.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/googollee/go-socket.io/engineio/session"
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/logger"
 )
 
 const (

--- a/parser/decoder_test.go
+++ b/parser/decoder_test.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"bytes"
-	"github.com/googollee/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/engineio/session"
 	"io"
 	"reflect"
 	"testing"

--- a/parser/encoder.go
+++ b/parser/encoder.go
@@ -6,8 +6,8 @@ import (
 	"io"
 	"reflect"
 
-	"github.com/googollee/go-socket.io/engineio/session"
-	"github.com/googollee/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/logger"
 )
 
 type FrameWriter interface {

--- a/parser/encoder_test.go
+++ b/parser/encoder_test.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"bytes"
-	"github.com/googollee/go-socket.io/engineio/session"
+	"github.com/feederco/go-socket.io/engineio/session"
 	"io"
 	"reflect"
 	"testing"

--- a/server.go
+++ b/server.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/gomodule/redigo/redis"
 
-	"github.com/googollee/go-socket.io/engineio"
-	"github.com/googollee/go-socket.io/logger"
-	"github.com/googollee/go-socket.io/parser"
+	"github.com/feederco/go-socket.io/engineio"
+	"github.com/feederco/go-socket.io/logger"
+	"github.com/feederco/go-socket.io/parser"
 )
 
 // Server is a go-socket.io server.


### PR DESCRIPTION
Since you're the endorsed maintainers of socket.io for go, this repository should be actually importable

I updated the module name and the import paths. I also rebased on the original repo to include the last commit, so you're not behind anymore.

I did not yet update the readme or the examples, but will do this if you agree to merge this PR.